### PR TITLE
Update commands.txt

### DIFF
--- a/section_4/live_activity_5/commands.txt
+++ b/section_4/live_activity_5/commands.txt
@@ -4,7 +4,7 @@
 aws lambda list-functions --region us-east-1
 
 // Creating our function.
-aws lambda create-function --region us-east-1 --function-name "ListS3Buckets" --runtime "nodejs8.10" --role "<COPY PASTE ROLE ARN HERE>" --handler "lambda_function.handler" --zip-file fileb:///home/cloud_user/lambda_function.zip
+aws lambda create-function --region us-east-1 --function-name "ListS3Buckets" --runtime "nodejs12.x" --role "<COPY PASTE ROLE ARN HERE>" --handler "lambda_function.handler" --zip-file fileb:///home/cloud_user/lambda_function.zip
 
 // Updating our use case function.
 aws lambda update-function-configuration --region us-east-1 --function-name "ListS3Buckets" --description "Creating our S3 function via CLI." --timeout 5 --memory-size 256


### PR DESCRIPTION
The AMI used in this lab may need to have the updated version of node, not sure. I used `nvm install 12.1` and `nvm use 12.1` in the EC2 instance before executing the lab, and was able to successfully complete it. I'm submitting a pull request for this even though you slapped "use `node12.x`" as a subtitle in the lab video, because the video control bar covers the text, and it wasn't until after I updated node and adjusted my JS function that I saw the text.